### PR TITLE
Remove ARMv7 container build

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -48,7 +48,7 @@ jobs:
           file: docker/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: true
-          platforms: linux/amd64, linux/arm64, linux/arm/v7
+          platforms: linux/amd64,linux/arm64
       - name: Publish README.md to Docker Hub
         uses: peter-evans/dockerhub-description@v4
         with:


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
This is just hanging when building on GH Actions and we don't need it for FF Cloud

