### PR TITLE
Use is-utf to validate string payload

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,5 +28,6 @@ process.on('SIGTERM', async () => {
 })
 
 app.listen(port, () => {
+    console.log(`MQTT Schema Agent running - pid ${process.pid}`)
     console.log(`listening on port ${port}`)
 })

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,4 +1,5 @@
 const got = require('got')
+const isUtf8 = require('is-utf8')
 const mqtt = require('mqtt')
 
 const schemaGen = require('./schema-generator')
@@ -123,26 +124,26 @@ class Agent {
                 // console.log(topic)
                 let type = { type: 'unknown' }
                 try {
-                    const stringPayload = payload.toString('utf8')
-                    type = { type: 'string' }
-                    switch (stringPayload.charAt(0)) {
-                    case '<':
-                        // probably XML
-                        type = { type: 'xml' }
-                        break
-                    case '{':
-                    case '[':
-                        // probably JSON
-                        try {
-                            const json = JSON.parse(stringPayload)
-                            type = schemaGen.generateSchema(json)
-                        } catch (err) {
-                            console.log(err)
+                    if (isUtf8(payload)) {
+                        const stringPayload = payload.toString('utf8')
+                        type = { type: 'string' }
+                        if (stringPayload.charAt(0) === '<' && stringPayload.charAt(stringPayload.length - 1) === '>') {
+                            type.type = 'xml'
+                        } else {
+                            try {
+                                const json = JSON.parse(stringPayload)
+                                type = schemaGen.generateSchema(json)
+                            } catch (err) {
+                                // Not JSON parseable - default to string
+                            }
                         }
+                    } else {
+                        type.type = 'bin'
                     }
                 } catch (err) {
-                    console.log(err)
+                    console.log(`Error parsing payload on topic '${topic}' ${err}`)
                 }
+                // console.log(topic, type)
                 agent.topics[topic] = {
                     timestamp: Date.now(),
                     type

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "body-parser": "^1.20.3",
         "express": "^4.21.2",
         "got": "^11.8.6",
+        "is-utf8": "^0.2.1",
         "mqtt": "^5.10.3"
       },
       "bin": {
@@ -3214,6 +3215,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "body-parser": "^1.20.3",
     "express": "^4.21.2",
     "got": "^11.8.6",
+    "is-utf8": "^0.2.1",
     "mqtt": "^5.10.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates the schema detection to use is-utf module to detect string vs binary payloads as efficiently as we can.

Lets `JSON.parse()` run on more cases as it will handle numbers/booleans as well.

Adds the process pid to the log output as it makes life easier when having to manually kill/restart the process during local development.