### PR TITLE
Add topic prefix support

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -65,7 +65,7 @@ class Agent {
                 console.log(`connected to ${agent.creds.host}:${agent.creds.port} as ${options.clientId}`)
                 agent.error = null
                 const topic = agent.creds.topicPrefix || '#'
-                console.log(`subscribing to ${topic}`)
+                console.log(`subscribing to "${topic}"`)
                 agent.client.subscribe(topic)
             })
             this.client.on('subscribe', function () {

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -64,7 +64,8 @@ class Agent {
                 agent.connected = true
                 console.log(`connected to ${agent.creds.host}:${agent.creds.port} as ${options.clientId}`)
                 agent.error = null
-                const topic = agent.creds.topic || '#'
+                const topic = agent.creds.topicPrefix || '#'
+                console.log(`subscribing to ${topic}`)
                 agent.client.subscribe(topic)
             })
             this.client.on('subscribe', function () {

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -64,7 +64,8 @@ class Agent {
                 agent.connected = true
                 console.log(`connected to ${agent.creds.host}:${agent.creds.port} as ${options.clientId}`)
                 agent.error = null
-                agent.client.subscribe('#')
+                const topic = agent.creds.topic || '#'
+                agent.client.subscribe(topic)
             })
             this.client.on('subscribe', function () {
                 // on successful subscribe reset reconnect count

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowfuse/mqtt-schema-agent",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Agent to collect MQTT topic Schema",
   "main": "index.js",
   "homepage": "https://flowfuse.com",


### PR DESCRIPTION
closes FlowFuse/flowfuse#5338

## Description

<!-- Describe your changes in detail -->
Allows to subscribe to a prefix if broker doesn't allow '#'

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

