### PR TITLE
ci: Add generic `.npmignore` file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,64 @@
+# Test files
+test/
+*.spec.js
+*.test.js
+
+# Development files
+.eslintrc
+.eslintrc.js
+.eslintrc.json
+.eslintignore
+.editorconfig
+
+# CI/CD
+.github/
+
+# Docker
+docker/
+Dockerfile
+.dockerignore
+docker-compose.yml
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Documentation (keep README, LICENSE, CHANGELOG)
+docs/
+*.md
+!README.md
+!CHANGELOG.md
+
+# Coverage and reports
+coverage/
+.nyc_output/
+*.lcov
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Build artifacts (if applicable)
+dist/
+build/
+
+# Misc
+.npmrc
+.yarnrc


### PR DESCRIPTION
## Description

This pull request adds the `.npmignore` file with a generic content.


## Related Issue(s)

* https://github.com/FlowFuse/helm/security/code-scanning/3561
* https://github.com/FlowFuse/helm/security/code-scanning/3560

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

