### PR TITLE
ci: Add Product board project-automation workflow

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,11 @@
+name: Project automations
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  add_issue_to_relevant_boards:
+    uses: flowfuse/github-actions-workflows/.github/workflows/project-automation.yaml@project-automation/v1
+    secrets:
+      app-client-id: ${{ secrets.GH_BOT_APP_ID }}
+      app-private-key: ${{ secrets.GH_BOT_APP_KEY }}


### PR DESCRIPTION
## Summary
Adds the standard caller workflow so newly created issues are added to the Product board.

Part of FlowFuse/admin#587